### PR TITLE
抓取美团票价时处理CSS部分正则表达式问题

### DIFF
--- a/scraper/ticket.js
+++ b/scraper/ticket.js
@@ -326,7 +326,7 @@ var getTicketsFromMeituan = function (movieMeituanId, cinemaMeituanId, callback)
                                         var className = /(true\d+)/.exec($(this).attr('class'))[0];
                                         $(this).find('i').each(function (index) {
                                             var num = $(this).text();
-                                            var reg = new RegExp(className + ">i:nth-of-type\\(" + (index + 1) + "\\)\\{text-indent:(\\S+)em;width:(\\S+)em;}");
+                                            var reg = new RegExp(className + ">i:nth-of-type\\(" + (index + 1) + "\\)\\{text-indent:(\\S+)em;width:(\\S+)em;");
                                             var offset = reg.exec(css)[1];
                                             var width = reg.exec(css)[2];
                                             if (width == '0.55') {


### PR DESCRIPTION
CSS文件中每行类似这样
`.true2>i:nth-of-type(1){text-indent:-1.2em;width:0.0em;font-family: Courier;}`
原来的正则规则多写了一个'{'
